### PR TITLE
False swipe value modify

### DIFF
--- a/PROBot/BattleAI.cs
+++ b/PROBot/BattleAI.cs
@@ -6,11 +6,11 @@ namespace PROBot
 {
     public class BattleAI
     {
+        private const int FalseSwipe = 1;
         private const int DoubleEdge = 70;
         private const int DragonRage = 74;
         private const int DreamEater = 76;
         private const int Explosion = 87;
-        private const int FalseSwipe = 93;
         private const int NightShade = 193;
         private const int Psywave = 217;
         private const int SeismicToss = 249;


### PR DESCRIPTION
False swipe can not kill therefore should only be used with WeakAttack(). This should also be prioritize with WeakAttack() and set to the lowest value (1?), as its primary function is weakening without killing.
