### PR TITLE
Add some option sliders

### DIFF
--- a/PROBot/BotClient.cs
+++ b/PROBot/BotClient.cs
@@ -37,6 +37,7 @@ namespace PROBot
         public StaffAvoider StaffAvoider { get; private set; }
         public AutoReconnector AutoReconnector { get; private set; }
         public MovementResynchronizer MovementResynchronizer { get; private set; }
+        public OptionSlider[] Options { get; private set; }
         
         private bool _loginRequested;
 
@@ -51,6 +52,12 @@ namespace PROBot
             AutoReconnector = new AutoReconnector(this);
             MovementResynchronizer = new MovementResynchronizer(this);
             Rand = new Random();
+            Options = new OptionSlider[] { new OptionSlider("Option 1: ", "Custom option 1 for use in scripts"),
+                                           new OptionSlider("Option 2: ", "Custom option 2 for use in scripts"),
+                                           new OptionSlider("Option 3: ", "Custom option 3 for use in scripts"),
+                                           new OptionSlider("Option 4: ", "Custom option 4 for use in scripts"),
+                                           new OptionSlider("Option 5: ", "Custom option 5 for use in scripts")
+            };
         }
 
         public void LogMessage(string message)

--- a/PROBot/BotClient.cs
+++ b/PROBot/BotClient.cs
@@ -52,11 +52,11 @@ namespace PROBot
             AutoReconnector = new AutoReconnector(this);
             MovementResynchronizer = new MovementResynchronizer(this);
             Rand = new Random();
-            Options = new OptionSlider[] { new OptionSlider("Option 1: ", "Custom option 1 for use in scripts"),
-                                           new OptionSlider("Option 2: ", "Custom option 2 for use in scripts"),
-                                           new OptionSlider("Option 3: ", "Custom option 3 for use in scripts"),
-                                           new OptionSlider("Option 4: ", "Custom option 4 for use in scripts"),
-                                           new OptionSlider("Option 5: ", "Custom option 5 for use in scripts")
+            Options = new OptionSlider[] { new OptionSlider("Option 1: ", "Custom option 1 for use in scripts", 1),
+                                           new OptionSlider("Option 2: ", "Custom option 2 for use in scripts", 2),
+                                           new OptionSlider("Option 3: ", "Custom option 3 for use in scripts", 3),
+                                           new OptionSlider("Option 4: ", "Custom option 4 for use in scripts", 4),
+                                           new OptionSlider("Option 5: ", "Custom option 5 for use in scripts", 5)
             };
         }
 

--- a/PROBot/Modules/OptionSlider.cs
+++ b/PROBot/Modules/OptionSlider.cs
@@ -4,11 +4,12 @@ namespace PROBot.Modules
 {
     public class OptionSlider
     {
-        public event Action<bool> EnabledStateChanged;
-        public event Action<string> NameChanged, DescriptionChanged;
+        public event Action<bool, int> EnabledStateChanged;
+        public event Action<string, int> NameChanged, DescriptionChanged;
 
         private bool _isEnabled = false;
         private string _name, _description;
+        private int _index;
 
         public bool IsEnabled
         {
@@ -18,7 +19,7 @@ namespace PROBot.Modules
                 if (_isEnabled != value)
                 {
                     _isEnabled = value;
-                    EnabledStateChanged?.Invoke(value);
+                    EnabledStateChanged?.Invoke(value, _index);
                 }
             }
         }
@@ -31,7 +32,7 @@ namespace PROBot.Modules
                 if (_name != value)
                 {
                     _name = value;
-                    NameChanged?.Invoke(value);
+                    NameChanged?.Invoke(value, _index);
                 }
             }
         }
@@ -44,15 +45,16 @@ namespace PROBot.Modules
                 if (_description != value)
                 {
                     _description = value;
-                    DescriptionChanged?.Invoke(value);
+                    DescriptionChanged?.Invoke(value, _index);
                 }
             }
         }
 
-        public OptionSlider (string name, string description)
+        public OptionSlider (string name, string description, int index)
         {
             _name = name;
             _description = description;
+            _index = index;
         }
     }
 }

--- a/PROBot/Modules/OptionSlider.cs
+++ b/PROBot/Modules/OptionSlider.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace PROBot.Modules
+{
+    public class OptionSlider
+    {
+        public event Action<bool> EnabledStateChanged;
+        public event Action<string> NameChanged, DescriptionChanged;
+
+        private bool _isEnabled = false;
+        private string _name, _description;
+
+        public bool IsEnabled
+        {
+            get { return _isEnabled; }
+            set
+            {
+                if (_isEnabled != value)
+                {
+                    _isEnabled = value;
+                    EnabledStateChanged?.Invoke(value);
+                }
+            }
+        }
+
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    NameChanged?.Invoke(value);
+                }
+            }
+        }
+
+        public string Description
+        {
+            get { return _description; }
+            set
+            {
+                if (_description != value)
+                {
+                    _description = value;
+                    DescriptionChanged?.Invoke(value);
+                }
+            }
+        }
+
+        public OptionSlider (string name, string description)
+        {
+            _name = name;
+            _description = description;
+        }
+    }
+}

--- a/PROBot/Modules/OptionSlider.cs
+++ b/PROBot/Modules/OptionSlider.cs
@@ -10,6 +10,11 @@ namespace PROBot.Modules
         private bool _isEnabled = false;
         private string _name, _description;
         private int _index;
+        
+        public void Reset()
+        {
+            _isEnabled = false;
+        }
 
         public bool IsEnabled
         {

--- a/PROBot/Modules/OptionSlider.cs
+++ b/PROBot/Modules/OptionSlider.cs
@@ -14,6 +14,8 @@ namespace PROBot.Modules
         public void Reset()
         {
             _isEnabled = false;
+            _name = "Option " + _index + ": ";
+            _description = "Custom option " + _index + " for use in scripts";
         }
 
         public bool IsEnabled

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -282,6 +282,12 @@ namespace PROBot.Scripting
             // Move learning actions
             _lua.Globals["forgetMove"] = new Func<string, bool>(ForgetMove);
             _lua.Globals["forgetAnyMoveExcept"] = new Func<DynValue[], bool>(ForgetAnyMoveExcept);
+            
+            // Custom option slider functions
+            _lua.Globals["setOption"] = new Action<int, bool>(SetOption);
+            _lua.Globals["getOption"] = new Func<int, bool>(GetOption);
+            _lua.Globals["setOptionName"] = new Action<int, string>(SetOptionName);
+            _lua.Globals["setOptionDescription"] = new Action<int, string>(SetOptionDescription);
 
             foreach (string content in _libsContent)
             {
@@ -2285,6 +2291,38 @@ namespace PROBot.Scripting
                 return true;
             }
             return false;
+        }
+
+        private void SetOption(int option, bool value)
+        {
+            if (option < 1 || option > Bot.Options.Length)
+                return;
+
+            Bot.Options[option - 1].IsEnabled = value;
+        }
+
+        private bool GetOption(int option)
+        {
+            if (option < 1 || option > Bot.Options.Length)
+                return false;
+
+            return Bot.Options[option - 1].IsEnabled;
+        }
+
+        private void SetOptionName(int option, string content)
+        {
+            if (option < 1 || option > Bot.Options.Length)
+                return;
+
+            Bot.Options[option - 1].Name = content + ": ";
+        }
+
+        private void SetOptionDescription(int option, string content)
+        {
+            if (option < 1 || option > Bot.Options.Length)
+                return;
+
+            Bot.Options[option - 1].Description = content;
         }
     }
 }

--- a/PROShine/Views/MainWindow.xaml
+++ b/PROShine/Views/MainWindow.xaml
@@ -173,27 +173,27 @@
                 </CheckBox.ToolTip>
             </CheckBox>
             <WrapPanel>
-                <CheckBox x:Name="ScriptOption1" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 1: " Checked="Option1_Checked" Unchecked="Option1_Unchecked">
+                <CheckBox x:Name="ScriptOption1" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 1: " Checked="Option_Checked" Unchecked="Option_Unchecked">
                     <CheckBox.ToolTip>
                         <TextBlock><Run Text="Custom option 1 for use in scripts"/></TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
-                <CheckBox x:Name="ScriptOption2" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 2: " Checked="Option2_Checked" Unchecked="Option2_Unchecked">
+                <CheckBox x:Name="ScriptOption2" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 2: " Checked="Option_Checked" Unchecked="Option_Unchecked">
                     <CheckBox.ToolTip>
                         <TextBlock><Run Text="Custom option 2 for use in scripts"/></TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
-                <CheckBox x:Name="ScriptOption3" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 3: " Checked="Option3_Checked" Unchecked="Option3_Unchecked">
+                <CheckBox x:Name="ScriptOption3" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 3: " Checked="Option_Checked" Unchecked="Option_Unchecked">
                     <CheckBox.ToolTip>
                         <TextBlock><Run Text="Custom option 3 for use in scripts"/></TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
-                <CheckBox x:Name="ScriptOption4" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 4: " Checked="Option4_Checked" Unchecked="Option4_Unchecked">
+                <CheckBox x:Name="ScriptOption4" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 4: " Checked="Option_Checked" Unchecked="Option_Unchecked">
                     <CheckBox.ToolTip>
                         <TextBlock><Run Text="Custom option 4 for use in scripts"/></TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
-                <CheckBox x:Name="ScriptOption5" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 5: " Checked="Option5_Checked" Unchecked="Option5_Unchecked">
+                <CheckBox x:Name="ScriptOption5" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 5: " Checked="Option_Checked" Unchecked="Option_Unchecked">
                     <CheckBox.ToolTip>
                         <TextBlock><Run Text="Custom option 5 for use in scripts"/></TextBlock>
                     </CheckBox.ToolTip>

--- a/PROShine/Views/MainWindow.xaml
+++ b/PROShine/Views/MainWindow.xaml
@@ -172,6 +172,33 @@
                     <TextBlock>Reconnect after a few minutes and start the last script.</TextBlock>
                 </CheckBox.ToolTip>
             </CheckBox>
+            <WrapPanel>
+                <CheckBox x:Name="ScriptOption1" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 1: " Checked="Option1_Checked" Unchecked="Option1_Unchecked">
+                    <CheckBox.ToolTip>
+                        <TextBlock><Run Text="Custom option 1 for use in scripts"/></TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <CheckBox x:Name="ScriptOption2" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 2: " Checked="Option2_Checked" Unchecked="Option2_Unchecked">
+                    <CheckBox.ToolTip>
+                        <TextBlock><Run Text="Custom option 2 for use in scripts"/></TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <CheckBox x:Name="ScriptOption3" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 3: " Checked="Option3_Checked" Unchecked="Option3_Unchecked">
+                    <CheckBox.ToolTip>
+                        <TextBlock><Run Text="Custom option 3 for use in scripts"/></TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <CheckBox x:Name="ScriptOption4" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 4: " Checked="Option4_Checked" Unchecked="Option4_Unchecked">
+                    <CheckBox.ToolTip>
+                        <TextBlock><Run Text="Custom option 4 for use in scripts"/></TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <CheckBox x:Name="ScriptOption5" Style="{StaticResource SwitchStyle}" Margin="2,1,2,1" Content="Option 5: " Checked="Option5_Checked" Unchecked="Option5_Unchecked">
+                    <CheckBox.ToolTip>
+                        <TextBlock><Run Text="Custom option 5 for use in scripts"/></TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
+            </WrapPanel>
         </WrapPanel>
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -276,7 +276,7 @@ namespace PROShine
                             _options[i].Visibility = Visibility.Collapsed;
                             _options[i].IsChecked = false;
                             _options[i].Content = "Option " + (i + 1) + ": ";
-                            _options[i].ToolTip = "Custom option  " + (i + 1) + " for use in scripts";
+                            _options[i].ToolTip = "Custom option " + (i + 1) + " for use in scripts";
                         }
                         
                         Bot.LoadScript(openDialog.FileName);

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -62,11 +62,11 @@ namespace PROShine
             Bot.ConnectionClosed += Bot_ConnectionClosed;
             Bot.MessageLogged += Bot_LogMessage;
 
-            for (int i = 0; i < Bot.Options.Length; i++)
+            foreach (var slider in Bot.Options)
             {
-                Bot.Options[i].EnabledStateChanged += Bot_OptionStateChanged;
-                Bot.Options[i].NameChanged += Bot_OptionNameChanged;
-                Bot.Options[i].DescriptionChanged += Bot_OptionDescriptionChanged;
+                slider.EnabledStateChanged += Bot_OptionStateChanged;
+                slider.NameChanged += Bot_OptionNameChanged;
+                slider.DescriptionChanged += Bot_OptionDescriptionChanged;
             }
 
             InitializeComponent();

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -62,6 +62,22 @@ namespace PROShine
             Bot.ConnectionClosed += Bot_ConnectionClosed;
             Bot.MessageLogged += Bot_LogMessage;
 
+            Bot.Options[0].EnabledStateChanged += Bot_Option1StateChanged;
+            Bot.Options[0].NameChanged += Bot_Option1NameChanged;
+            Bot.Options[0].DescriptionChanged += Bot_Option1DescriptionChanged;
+            Bot.Options[1].EnabledStateChanged += Bot_Option2StateChanged;
+            Bot.Options[1].NameChanged += Bot_Option2NameChanged;
+            Bot.Options[1].DescriptionChanged += Bot_Option2DescriptionChanged;
+            Bot.Options[2].EnabledStateChanged += Bot_Option3StateChanged;
+            Bot.Options[2].NameChanged += Bot_Option3NameChanged;
+            Bot.Options[2].DescriptionChanged += Bot_Option3DescriptionChanged;
+            Bot.Options[3].EnabledStateChanged += Bot_Option4StateChanged;
+            Bot.Options[3].NameChanged += Bot_Option4NameChanged;
+            Bot.Options[3].DescriptionChanged += Bot_Option4DescriptionChanged;
+            Bot.Options[4].EnabledStateChanged += Bot_Option5StateChanged;
+            Bot.Options[4].NameChanged += Bot_Option5NameChanged;
+            Bot.Options[4].DescriptionChanged += Bot_Option5DescriptionChanged;
+
             InitializeComponent();
             AutoReconnectSwitch.IsChecked = Bot.AutoReconnector.IsEnabled;
             AvoidStaffSwitch.IsChecked = Bot.StaffAvoider.IsEnabled;
@@ -467,6 +483,136 @@ namespace PROShine
             });
         }
 
+        private void Bot_Option1StateChanged(bool value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if (ScriptOption1.IsChecked == value) return;
+                ScriptOption1.IsChecked = value;
+            });
+        }
+
+        private void Bot_Option1NameChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if ((string)ScriptOption1.Content == value) return;
+                ScriptOption1.Content = value;
+            });
+        }
+
+        private void Bot_Option1DescriptionChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                ScriptOption1.ToolTip = value;
+            });
+        }
+
+        private void Bot_Option2StateChanged(bool value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if (ScriptOption2.IsChecked == value) return;
+                ScriptOption2.IsChecked = value;
+            });
+        }
+
+        private void Bot_Option2NameChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if ((string)ScriptOption2.Content == value) return;
+                ScriptOption2.Content = value;
+            });
+        }
+
+        private void Bot_Option2DescriptionChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                ScriptOption2.ToolTip = value;
+            });
+        }
+
+        private void Bot_Option3StateChanged(bool value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if (ScriptOption3.IsChecked == value) return;
+                ScriptOption3.IsChecked = value;
+            });
+        }
+
+        private void Bot_Option3NameChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if ((string)ScriptOption3.Content == value) return;
+                ScriptOption3.Content = value;
+            });
+        }
+
+        private void Bot_Option3DescriptionChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                ScriptOption3.ToolTip = value;
+            });
+        }
+
+        private void Bot_Option4StateChanged(bool value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if (ScriptOption4.IsChecked == value) return;
+                ScriptOption4.IsChecked = value;
+            });
+        }
+
+        private void Bot_Option4NameChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if ((string)ScriptOption4.Content == value) return;
+                ScriptOption4.Content = value;
+            });
+        }
+
+        private void Bot_Option4DescriptionChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                ScriptOption4.ToolTip = value;
+            });
+        }
+
+        private void Bot_Option5StateChanged(bool value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if (ScriptOption5.IsChecked == value) return;
+                ScriptOption5.IsChecked = value;
+            });
+        }
+
+        private void Bot_Option5NameChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                if ((string)ScriptOption5.Content == value) return;
+                ScriptOption5.Content = value;
+            });
+        }
+
+        private void Bot_Option5DescriptionChanged(string value)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                ScriptOption5.ToolTip = value;
+            });
+        }
+
         private void Bot_ClientChanged()
         {
             lock (Bot)
@@ -804,6 +950,86 @@ namespace PROShine
             lock (Bot)
             {
                 Bot.AutoReconnector.IsEnabled = false;
+            }
+        }
+
+        private void Option1_Checked(object sender, RoutedEventArgs e)
+        {
+            lock(Bot)
+            {
+                Bot.Options[0].IsEnabled = true;
+            }
+        }
+
+        private void Option1_Unchecked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[0].IsEnabled = false;
+            }
+        }
+
+        private void Option2_Checked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[1].IsEnabled = true;
+            }
+        }
+
+        private void Option2_Unchecked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[1].IsEnabled = false;
+            }
+        }
+
+        private void Option3_Checked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[2].IsEnabled = true;
+            }
+        }
+
+        private void Option3_Unchecked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[2].IsEnabled = false;
+            }
+        }
+
+        private void Option4_Checked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[3].IsEnabled = true;
+            }
+        }
+
+        private void Option4_Unchecked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[3].IsEnabled = false;
+            }
+        }
+
+        private void Option5_Checked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[4].IsEnabled = true;
+            }
+        }
+
+        private void Option5_Unchecked(object sender, RoutedEventArgs e)
+        {
+            lock (Bot)
+            {
+                Bot.Options[4].IsEnabled = false;
             }
         }
 

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -275,8 +275,8 @@ namespace PROShine
                         {
                             _options[i].Visibility = Visibility.Collapsed;
                             _options[i].IsChecked = false;
-                            _options[i].Content = "Option " + (i + 1) + ": ";
-                            _options[i].ToolTip = "Custom option " + (i + 1) + " for use in scripts";
+                            _options[i].Content = Bot.Options[i].Name;
+                            _options[i].ToolTip = Bot.Options[i].Description;
                         }
                         
                         Bot.LoadScript(openDialog.FileName);

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -62,21 +62,12 @@ namespace PROShine
             Bot.ConnectionClosed += Bot_ConnectionClosed;
             Bot.MessageLogged += Bot_LogMessage;
 
-            Bot.Options[0].EnabledStateChanged += Bot_Option1StateChanged;
-            Bot.Options[0].NameChanged += Bot_Option1NameChanged;
-            Bot.Options[0].DescriptionChanged += Bot_Option1DescriptionChanged;
-            Bot.Options[1].EnabledStateChanged += Bot_Option2StateChanged;
-            Bot.Options[1].NameChanged += Bot_Option2NameChanged;
-            Bot.Options[1].DescriptionChanged += Bot_Option2DescriptionChanged;
-            Bot.Options[2].EnabledStateChanged += Bot_Option3StateChanged;
-            Bot.Options[2].NameChanged += Bot_Option3NameChanged;
-            Bot.Options[2].DescriptionChanged += Bot_Option3DescriptionChanged;
-            Bot.Options[3].EnabledStateChanged += Bot_Option4StateChanged;
-            Bot.Options[3].NameChanged += Bot_Option4NameChanged;
-            Bot.Options[3].DescriptionChanged += Bot_Option4DescriptionChanged;
-            Bot.Options[4].EnabledStateChanged += Bot_Option5StateChanged;
-            Bot.Options[4].NameChanged += Bot_Option5NameChanged;
-            Bot.Options[4].DescriptionChanged += Bot_Option5DescriptionChanged;
+            for (int i = 0; i < Bot.Options.Length; i++)
+            {
+                Bot.Options[i].EnabledStateChanged += Bot_OptionStateChanged;
+                Bot.Options[i].NameChanged += Bot_OptionNameChanged;
+                Bot.Options[i].DescriptionChanged += Bot_OptionDescriptionChanged;
+            }
 
             InitializeComponent();
             AutoReconnectSwitch.IsChecked = Bot.AutoReconnector.IsEnabled;
@@ -107,6 +98,12 @@ namespace PROShine
             LogMessage("Running " + App.Name + " by " + App.Author + ", version " + App.Version);
 
             Task.Run(() => UpdateClients());
+
+            ScriptOption1.Visibility = Visibility.Collapsed;
+            ScriptOption2.Visibility = Visibility.Collapsed;
+            ScriptOption3.Visibility = Visibility.Collapsed;
+            ScriptOption4.Visibility = Visibility.Collapsed;
+            ScriptOption5.Visibility = Visibility.Collapsed;
         }
 
         private void AddView(UserControl view, ContentControl content, ToggleButton button, bool visible = false)
@@ -266,6 +263,12 @@ namespace PROShine
                 {
                     lock (Bot)
                     {
+                        ScriptOption1.Visibility = Visibility.Collapsed;
+                        ScriptOption2.Visibility = Visibility.Collapsed;
+                        ScriptOption3.Visibility = Visibility.Collapsed;
+                        ScriptOption4.Visibility = Visibility.Collapsed;
+                        ScriptOption5.Visibility = Visibility.Collapsed;
+                        
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;
                         LogMessage("Script \"{0}\" by \"{1}\" successfully loaded", Bot.Script.Name, Bot.Script.Author);
@@ -483,133 +486,93 @@ namespace PROShine
             });
         }
 
-        private void Bot_Option1StateChanged(bool value)
+        private void Bot_OptionStateChanged(bool value, int index)
         {
             Dispatcher.InvokeAsync(delegate
             {
-                if (ScriptOption1.IsChecked == value) return;
-                ScriptOption1.IsChecked = value;
+                switch(index)
+                {
+                    case (1):
+                        ScriptOption1.Visibility = Visibility.Visible;
+                        ScriptOption1.IsChecked = value;
+                        break;
+                    case (2):
+                        ScriptOption2.Visibility = Visibility.Visible;
+                        ScriptOption2.IsChecked = value;
+                        break;
+                    case (3):
+                        ScriptOption3.Visibility = Visibility.Visible;
+                        ScriptOption3.IsChecked = value;
+                        break;
+                    case (4):
+                        ScriptOption4.Visibility = Visibility.Visible;
+                        ScriptOption4.IsChecked = value;
+                        break;
+                    case (5):
+                        ScriptOption5.Visibility = Visibility.Visible;
+                        ScriptOption5.IsChecked = value;
+                        break;
+                }
             });
         }
 
-        private void Bot_Option1NameChanged(string value)
+        private void Bot_OptionNameChanged(string value, int index)
         {
             Dispatcher.InvokeAsync(delegate
             {
-                if ((string)ScriptOption1.Content == value) return;
-                ScriptOption1.Content = value;
+                switch (index)
+                {
+                    case (1):
+                        ScriptOption1.Visibility = Visibility.Visible;
+                        ScriptOption1.Content = value;
+                        break;
+                    case (2):
+                        ScriptOption2.Visibility = Visibility.Visible;
+                        ScriptOption2.Content = value;
+                        break;
+                    case (3):
+                        ScriptOption3.Visibility = Visibility.Visible;
+                        ScriptOption3.Content = value;
+                        break;
+                    case (4):
+                        ScriptOption4.Visibility = Visibility.Visible;
+                        ScriptOption4.Content = value;
+                        break;
+                    case (5):
+                        ScriptOption5.Visibility = Visibility.Visible;
+                        ScriptOption5.Content = value;
+                        break;
+                }
             });
         }
 
-        private void Bot_Option1DescriptionChanged(string value)
+        private void Bot_OptionDescriptionChanged(string value, int index)
         {
             Dispatcher.InvokeAsync(delegate
             {
-                ScriptOption1.ToolTip = value;
-            });
-        }
-
-        private void Bot_Option2StateChanged(bool value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if (ScriptOption2.IsChecked == value) return;
-                ScriptOption2.IsChecked = value;
-            });
-        }
-
-        private void Bot_Option2NameChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if ((string)ScriptOption2.Content == value) return;
-                ScriptOption2.Content = value;
-            });
-        }
-
-        private void Bot_Option2DescriptionChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                ScriptOption2.ToolTip = value;
-            });
-        }
-
-        private void Bot_Option3StateChanged(bool value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if (ScriptOption3.IsChecked == value) return;
-                ScriptOption3.IsChecked = value;
-            });
-        }
-
-        private void Bot_Option3NameChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if ((string)ScriptOption3.Content == value) return;
-                ScriptOption3.Content = value;
-            });
-        }
-
-        private void Bot_Option3DescriptionChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                ScriptOption3.ToolTip = value;
-            });
-        }
-
-        private void Bot_Option4StateChanged(bool value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if (ScriptOption4.IsChecked == value) return;
-                ScriptOption4.IsChecked = value;
-            });
-        }
-
-        private void Bot_Option4NameChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if ((string)ScriptOption4.Content == value) return;
-                ScriptOption4.Content = value;
-            });
-        }
-
-        private void Bot_Option4DescriptionChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                ScriptOption4.ToolTip = value;
-            });
-        }
-
-        private void Bot_Option5StateChanged(bool value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if (ScriptOption5.IsChecked == value) return;
-                ScriptOption5.IsChecked = value;
-            });
-        }
-
-        private void Bot_Option5NameChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                if ((string)ScriptOption5.Content == value) return;
-                ScriptOption5.Content = value;
-            });
-        }
-
-        private void Bot_Option5DescriptionChanged(string value)
-        {
-            Dispatcher.InvokeAsync(delegate
-            {
-                ScriptOption5.ToolTip = value;
+                switch (index)
+                {
+                    case (1):
+                        ScriptOption1.Visibility = Visibility.Visible;
+                        ScriptOption1.ToolTip = value;
+                        break;
+                    case (2):
+                        ScriptOption2.Visibility = Visibility.Visible;
+                        ScriptOption2.ToolTip = value;
+                        break;
+                    case (3):
+                        ScriptOption3.Visibility = Visibility.Visible;
+                        ScriptOption3.ToolTip = value;
+                        break;
+                    case (4):
+                        ScriptOption4.Visibility = Visibility.Visible;
+                        ScriptOption4.ToolTip = value;
+                        break;
+                    case (5):
+                        ScriptOption5.Visibility = Visibility.Visible;
+                        ScriptOption5.ToolTip = value;
+                        break;
+                }
             });
         }
 

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -269,6 +269,9 @@ namespace PROShine
                         ScriptOption4.Visibility = Visibility.Collapsed;
                         ScriptOption5.Visibility = Visibility.Collapsed;
                         
+                        foreach (var slider in Bot.Options)
+                            slider.IsEnabled = false;
+                        
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;
                         LogMessage("Script \"{0}\" by \"{1}\" successfully loaded", Bot.Script.Name, Bot.Script.Author);

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -263,6 +263,9 @@ namespace PROShine
                 {
                     lock (Bot)
                     {
+                        /*
+                        Setting each slider to false in this way can cause the bot to freeze. A better solution is needed.
+                        
                         ScriptOption1.Visibility = Visibility.Collapsed;
                         ScriptOption2.Visibility = Visibility.Collapsed;
                         ScriptOption3.Visibility = Visibility.Collapsed;
@@ -271,6 +274,7 @@ namespace PROShine
                         
                         foreach (var slider in Bot.Options)
                             slider.IsEnabled = false;
+                        */
                         
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -863,83 +863,23 @@ namespace PROShine
             }
         }
 
-        private void Option1_Checked(object sender, RoutedEventArgs e)
+        private void Option_Checked(object sender, RoutedEventArgs e)
         {
             lock(Bot)
             {
-                Bot.Options[0].IsEnabled = true;
+                for (int i = 0; i < _options.Length; i++)
+                    if (_options[i] == sender)
+                        Bot.Options[i].IsEnabled = true;
             }
         }
 
-        private void Option1_Unchecked(object sender, RoutedEventArgs e)
+        private void Option_Unchecked(object sender, RoutedEventArgs e)
         {
             lock (Bot)
             {
-                Bot.Options[0].IsEnabled = false;
-            }
-        }
-
-        private void Option2_Checked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[1].IsEnabled = true;
-            }
-        }
-
-        private void Option2_Unchecked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[1].IsEnabled = false;
-            }
-        }
-
-        private void Option3_Checked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[2].IsEnabled = true;
-            }
-        }
-
-        private void Option3_Unchecked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[2].IsEnabled = false;
-            }
-        }
-
-        private void Option4_Checked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[3].IsEnabled = true;
-            }
-        }
-
-        private void Option4_Unchecked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[3].IsEnabled = false;
-            }
-        }
-
-        private void Option5_Checked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[4].IsEnabled = true;
-            }
-        }
-
-        private void Option5_Unchecked(object sender, RoutedEventArgs e)
-        {
-            lock (Bot)
-            {
-                Bot.Options[4].IsEnabled = false;
+                for (int i = 0; i < _options.Length; i++)
+                    if (_options[i] == sender)
+                        Bot.Options[i].IsEnabled = false;
             }
         }
 

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -44,6 +44,8 @@ namespace PROShine
 
         private int _queuePosition;
 
+        private CheckBox[] _options = new CheckBox[5];
+
         public MainWindow()
         {
 #if !DEBUG
@@ -99,11 +101,14 @@ namespace PROShine
 
             Task.Run(() => UpdateClients());
 
-            ScriptOption1.Visibility = Visibility.Collapsed;
-            ScriptOption2.Visibility = Visibility.Collapsed;
-            ScriptOption3.Visibility = Visibility.Collapsed;
-            ScriptOption4.Visibility = Visibility.Collapsed;
-            ScriptOption5.Visibility = Visibility.Collapsed;
+            _options[0] = ScriptOption1;
+            _options[1] = ScriptOption2;
+            _options[2] = ScriptOption3;
+            _options[3] = ScriptOption4;
+            _options[4] = ScriptOption5;
+
+            foreach (var option in _options)
+                option.Visibility = Visibility.Collapsed;
         }
 
         private void AddView(UserControl view, ContentControl content, ToggleButton button, bool visible = false)
@@ -266,31 +271,13 @@ namespace PROShine
                         foreach (var slider in Bot.Options)
                             slider.Reset();
 
-                        ScriptOption1.Visibility = Visibility.Collapsed;
-                        ScriptOption2.Visibility = Visibility.Collapsed;
-                        ScriptOption3.Visibility = Visibility.Collapsed;
-                        ScriptOption4.Visibility = Visibility.Collapsed;
-                        ScriptOption5.Visibility = Visibility.Collapsed;
-
-                        // Surely there's a better way to do this
-
-                        ScriptOption1.IsChecked = false;
-                        ScriptOption2.IsChecked = false;
-                        ScriptOption3.IsChecked = false;
-                        ScriptOption4.IsChecked = false;
-                        ScriptOption5.IsChecked = false;
-
-                        ScriptOption1.Content = "Option1: ";
-                        ScriptOption2.Content = "Option2: ";
-                        ScriptOption3.Content = "Option3: ";
-                        ScriptOption4.Content = "Option4: ";
-                        ScriptOption5.Content = "Option5: ";
-
-                        ScriptOption1.ToolTip = "Custom option 1 for use in scripts";
-                        ScriptOption2.ToolTip = "Custom option 2 for use in scripts";
-                        ScriptOption3.ToolTip = "Custom option 3 for use in scripts";
-                        ScriptOption4.ToolTip = "Custom option 4 for use in scripts";
-                        ScriptOption5.ToolTip = "Custom option 5 for use in scripts";
+                        for (int i = 0; i < _options.Length; i++)
+                        {
+                            _options[i].Visibility = Visibility.Collapsed;
+                            _options[i].IsChecked = false;
+                            _options[i].Content = "Option " + (i + 1) + ": ";
+                            _options[i].ToolTip = "Custom option  " + (i + 1) + " for use in scripts";
+                        }
                         
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;
@@ -513,29 +500,8 @@ namespace PROShine
         {
             Dispatcher.InvokeAsync(delegate
             {
-                switch(index)
-                {
-                    case (1):
-                        ScriptOption1.Visibility = Visibility.Visible;
-                        ScriptOption1.IsChecked = value;
-                        break;
-                    case (2):
-                        ScriptOption2.Visibility = Visibility.Visible;
-                        ScriptOption2.IsChecked = value;
-                        break;
-                    case (3):
-                        ScriptOption3.Visibility = Visibility.Visible;
-                        ScriptOption3.IsChecked = value;
-                        break;
-                    case (4):
-                        ScriptOption4.Visibility = Visibility.Visible;
-                        ScriptOption4.IsChecked = value;
-                        break;
-                    case (5):
-                        ScriptOption5.Visibility = Visibility.Visible;
-                        ScriptOption5.IsChecked = value;
-                        break;
-                }
+                _options[index - 1].Visibility = Visibility.Visible;
+                _options[index - 1].IsChecked = value;
             });
         }
 
@@ -543,29 +509,8 @@ namespace PROShine
         {
             Dispatcher.InvokeAsync(delegate
             {
-                switch (index)
-                {
-                    case (1):
-                        ScriptOption1.Visibility = Visibility.Visible;
-                        ScriptOption1.Content = value;
-                        break;
-                    case (2):
-                        ScriptOption2.Visibility = Visibility.Visible;
-                        ScriptOption2.Content = value;
-                        break;
-                    case (3):
-                        ScriptOption3.Visibility = Visibility.Visible;
-                        ScriptOption3.Content = value;
-                        break;
-                    case (4):
-                        ScriptOption4.Visibility = Visibility.Visible;
-                        ScriptOption4.Content = value;
-                        break;
-                    case (5):
-                        ScriptOption5.Visibility = Visibility.Visible;
-                        ScriptOption5.Content = value;
-                        break;
-                }
+                _options[index - 1].Visibility = Visibility.Visible;
+                _options[index - 1].Content = value;
             });
         }
 
@@ -573,29 +518,8 @@ namespace PROShine
         {
             Dispatcher.InvokeAsync(delegate
             {
-                switch (index)
-                {
-                    case (1):
-                        ScriptOption1.Visibility = Visibility.Visible;
-                        ScriptOption1.ToolTip = value;
-                        break;
-                    case (2):
-                        ScriptOption2.Visibility = Visibility.Visible;
-                        ScriptOption2.ToolTip = value;
-                        break;
-                    case (3):
-                        ScriptOption3.Visibility = Visibility.Visible;
-                        ScriptOption3.ToolTip = value;
-                        break;
-                    case (4):
-                        ScriptOption4.Visibility = Visibility.Visible;
-                        ScriptOption4.ToolTip = value;
-                        break;
-                    case (5):
-                        ScriptOption5.Visibility = Visibility.Visible;
-                        ScriptOption5.ToolTip = value;
-                        break;
-                }
+                _options[index - 1].Visibility = Visibility.Visible;
+                _options[index - 1].ToolTip = value;
             });
         }
 

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -263,18 +263,20 @@ namespace PROShine
                 {
                     lock (Bot)
                     {
-                        /*
-                        Setting each slider to false in this way can cause the bot to freeze. A better solution is needed.
-                        
+                        foreach (var slider in Bot.Options)
+                            slider.Reset();
+
                         ScriptOption1.Visibility = Visibility.Collapsed;
                         ScriptOption2.Visibility = Visibility.Collapsed;
                         ScriptOption3.Visibility = Visibility.Collapsed;
                         ScriptOption4.Visibility = Visibility.Collapsed;
                         ScriptOption5.Visibility = Visibility.Collapsed;
-                        
-                        foreach (var slider in Bot.Options)
-                            slider.IsEnabled = false;
-                        */
+
+                        ScriptOption1.IsChecked = false;
+                        ScriptOption2.IsChecked = false;
+                        ScriptOption3.IsChecked = false;
+                        ScriptOption4.IsChecked = false;
+                        ScriptOption5.IsChecked = false;
                         
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -272,11 +272,25 @@ namespace PROShine
                         ScriptOption4.Visibility = Visibility.Collapsed;
                         ScriptOption5.Visibility = Visibility.Collapsed;
 
+                        // Surely there's a better way to do this
+
                         ScriptOption1.IsChecked = false;
                         ScriptOption2.IsChecked = false;
                         ScriptOption3.IsChecked = false;
                         ScriptOption4.IsChecked = false;
                         ScriptOption5.IsChecked = false;
+
+                        ScriptOption1.Content = "Option1: ";
+                        ScriptOption2.Content = "Option2: ";
+                        ScriptOption3.Content = "Option3: ";
+                        ScriptOption4.Content = "Option4: ";
+                        ScriptOption5.Content = "Option5: ";
+
+                        ScriptOption1.ToolTip = "Custom option 1 for use in scripts";
+                        ScriptOption2.ToolTip = "Custom option 2 for use in scripts";
+                        ScriptOption3.ToolTip = "Custom option 3 for use in scripts";
+                        ScriptOption4.ToolTip = "Custom option 4 for use in scripts";
+                        ScriptOption5.ToolTip = "Custom option 5 for use in scripts";
                         
                         Bot.LoadScript(openDialog.FileName);
                         MenuPathScript.Header = "Script: \"" + Bot.Script.Name + "\"" + Environment.NewLine + openDialog.FileName;


### PR DESCRIPTION
5 sliders for users to set at will, for scripters to alter script behavior according to activated sliders.
Both the name and the tooltip can be changed through a lua script.

Testing script:
```
log("Enabling all sliders")

names = {"Yo momma", "is so fat", "that her", "blood type", "is type Ragu"}

for i = 1, 5 do
	setOptionName(i, names[i])
	setOptionDescription(i, "This is Option " .. i .. "'s description, set by a script.\nThis is a new line.")
	setOption(i, true)
end

log("Option 1 is " .. tostring(getOption(1)) .. "!")
```