### PR TITLE
NPCs and Players added to Map, Debug infos on click

### DIFF
--- a/PROProtocol/Npc.cs
+++ b/PROProtocol/Npc.cs
@@ -2,6 +2,35 @@
 {
     public class Npc
     {
+        private static Dictionary<int, string> typeDescriptions = new Dictionary<int, string>()
+        {
+            //TODO: add all the npc types
+            {   1, "pokemon"},
+            {   2, "camper" },
+            {   3, "picnicker"},
+            {   4, "lass"},
+            {   6, "youngster m" },
+            {   7, "youngster f"},
+            {   8, "old man"},
+            {   9, "old lady"},
+            {  10, "interactive environment"},
+            {  11, "item" },
+            {  18, "scientist" },
+            {  19, "biker"},
+            {  17, "fisherman" },
+            {  25, "lass"},
+            {  33, "black belt" },
+            {  34, "sailor" },
+            {  44, "oran tree"},
+            {  61, "sitrus tree"},
+            {  69, "hiker"},
+            {  70, "digspot" },
+            {  71, "digspot" },
+            {  74, "chuck" },
+            { 101, "headbuttable tree" },
+            { 111, "bill" },
+        };
+        
         public int Id { get; private set; }
         public string Name { get; private set; }
         public bool IsBattler { get; private set; }
@@ -10,7 +39,8 @@
         public int PositionX { get; private set; }
         public int PositionY { get; private set; }
         public int LosLength { get; private set; }
-
+        public string TypeDescription { get { return (typeDescriptions.ContainsKey(Type) ? typeDescriptions[Type] + " ":"") + "(" + Type.ToString() + ")"; } }
+        
         public bool IsMoving { get { return _path.Length > 0; } }
 
         private string _path;

--- a/PROProtocol/Npc.cs
+++ b/PROProtocol/Npc.cs
@@ -1,4 +1,5 @@
-﻿namespace PROProtocol
+using System.Collections.Generic;
+namespace PROProtocol
 {
     public class Npc
     {

--- a/PROProtocol/Npc.cs
+++ b/PROProtocol/Npc.cs
@@ -5,7 +5,6 @@ namespace PROProtocol
     {
         private static Dictionary<int, string> typeDescriptions = new Dictionary<int, string>()
         {
-            //TODO: add all the npc types
             {   1, "pokemon"},
             {   2, "camper" },
             {   3, "picnicker"},
@@ -16,20 +15,37 @@ namespace PROProtocol
             {   9, "old lady"},
             {  10, "interactive environment"},
             {  11, "item" },
+            {  17, "fisherman" },
             {  18, "scientist" },
             {  19, "biker"},
-            {  17, "fisherman" },
             {  25, "lass"},
             {  33, "black belt" },
             {  34, "sailor" },
+            {  42, "cherry tree"},
+            {  43, "pecha tree"},
             {  44, "oran tree"},
+            {  45, "leppa tree"},
+            {  49, "chesto tree"},
+            {  50, "rawst tree"},
+            {  51, "aspear tree"},
+            {  52, "persim tree"},
+            {  55, "pomeg tree"},
+            {  56, "kelpsy tree"},
+            {  57, "qualot tree"},
+            {  58, "hondew tree"},
+            {  59, "grepa tree"},
+            {  60, "tomato tree"},
             {  61, "sitrus tree"},
+            {  62, "lum tree"},
+            {  63, "abandoned pokemon"},
             {  69, "hiker"},
-            {  70, "digspot" },
-            {  71, "digspot" },
+            {  70, "road digspot" },
+            {  71, "cave digspot" },
             {  74, "chuck" },
             { 101, "headbuttable tree" },
             { 111, "bill" },
+            { 119, "pokestop"},
+        };
         };
         
         public int Id { get; private set; }

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -556,6 +556,9 @@ namespace PROShine
                     Bot.Game.ShopOpened += Client_ShopOpened;
                     Bot.Game.MapLoaded += Map.Client_MapLoaded;
                     Bot.Game.PositionUpdated += Map.Client_PositionUpdated;
+                    Bot.Game.PlayerAdded += Map.Client_PlayerEnteredMap;
+                    Bot.Game.PlayerRemoved += Map.Client_PlayerLeftMap;
+                    Bot.Game.PlayerUpdated += Map.Client_PlayerMoved;
                 }
             }
             Dispatcher.InvokeAsync(delegate

--- a/PROShine/Views/MapView.xaml
+++ b/PROShine/Views/MapView.xaml
@@ -7,7 +7,11 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
-        <Canvas Name="MapCanvas" ClipToBounds="True">
+        <Canvas Name="MapCanvas" ClipToBounds="True" MouseMove="MapCanvas_MouseMove" MouseEnter="MapCanvas_MouseEnter" MouseLeave="MapCanvas_MouseLeave">
+            <!--  -->
+            <Popup Name="floatingTip" Placement="Relative" PlacementTarget="{Binding ElementName=MapCanvas}" IsOpen="True">
+                <TextBlock Name="tipText" Background="Gray"></TextBlock>
+            </Popup>
         </Canvas>
     </Grid>
 </UserControl>

--- a/PROShine/Views/MapView.xaml
+++ b/PROShine/Views/MapView.xaml
@@ -8,7 +8,6 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
         <Canvas Name="MapCanvas" ClipToBounds="True" MouseMove="MapCanvas_MouseMove" MouseEnter="MapCanvas_MouseEnter" MouseLeave="MapCanvas_MouseLeave">
-            <!--  -->
             <Popup Name="floatingTip" Placement="Relative" PlacementTarget="{Binding ElementName=MapCanvas}" IsOpen="True">
                 <TextBlock Name="tipText" Background="Gray"></TextBlock>
             </Popup>

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -302,6 +302,20 @@ namespace PROShine.Views
             Canvas.SetTop(_mapGrid, deltaY * _cellWidth);
             Canvas.SetLeft(_player, (_bot.Game.PlayerX + deltaX) * _cellWidth);
             Canvas.SetTop(_player, (_bot.Game.PlayerY + deltaY) * _cellWidth);
+            
+            PlayerInfos[] players = new PlayerInfos[_bot.Game.Players.Count];
+            _bot.Game.Players.Values.CopyTo(players, 0);
+            for(int i = 0; i<players.Length; i++)
+            {
+                Canvas.SetLeft(_otherPlayers[i], (players[i].PosX + deltaX) * _cellWidth);
+                Canvas.SetTop(_otherPlayers[i], (players[i].PosY + deltaY) * _cellWidth);
+            }
+
+            for(int i=0; i<_bot.Game.Map.Npcs.Count;i++)
+            {
+                Canvas.SetLeft(_npcs[i], (_bot.Game.Map.Npcs[i].PositionX + deltaX) * _cellWidth);
+                Canvas.SetTop(_npcs[i], (_bot.Game.Map.Npcs[i].PositionY + deltaY) * _cellWidth);
+            }
         }
 
         private Tuple<double, double> GetDrawingOffset()

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
+using System.Linq;
 
 namespace PROShine.Views
 {

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -102,12 +102,8 @@ namespace PROShine.Views
                 {
                     log += "    ID: " + npc.Id + "\r\n";
                     log += "        name: " + (npc.Name==""?"[unnamed]":npc.Name) + "\r\n";
-                    if(npc.IsBattler)
-                        log += "        type: Battler\r\n";
-                    else if(npc.Type==10)
-                        log += "        type: Headbutting Tree\r\n";
-                    else
-                        log += "        type: Standard\r\n";
+                    log += "        type: " + npc.TypeDescription + "\r\n";
+		    log += "        battler: " + npc.IsBattler.ToString() + "\r\n";
                 }
                 log += "\r\n";
             }

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -314,7 +314,7 @@ namespace PROShine.Views
                 Canvas.SetTop(_otherPlayers[i], (players[i].PosY + deltaY) * _cellWidth);
             }
 
-            for(int i=0; i<_bot.Game.Map.Npcs.Count;i++)
+            for(int i=0; i<_npcs.Length;i++)
             {
                 Canvas.SetLeft(_npcs[i], (_bot.Game.Map.Npcs[i].PositionX + deltaX) * _cellWidth);
                 Canvas.SetTop(_npcs[i], (_bot.Game.Map.Npcs[i].PositionY + deltaY) * _cellWidth);

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -57,7 +57,7 @@ namespace PROShine.Views
             Keyboard.Focus(this);
             
             if (_bot.Game != null)
-	        {
+	    {
                 //calculate clicked cell
                 Tuple<double, double> drawingOffset = GetDrawingOffset();
                 double deltaX = drawingOffset.Item1;

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -56,14 +56,17 @@ namespace PROShine.Views
         {
             Keyboard.Focus(this);
             
-            //calculate clicked cell
-            Tuple<double, double> drawingOffset = GetDrawingOffset();
-            double deltaX = drawingOffset.Item1;
-            double deltaY = drawingOffset.Item2;
-            int ingameX = (int)((e.GetPosition(this).X/_cellWidth - deltaX));
-            int ingameY = (int)((e.GetPosition(this).Y / _cellWidth) - deltaY);
+            if (_bot.Game != null)
+	        {
+                //calculate clicked cell
+                Tuple<double, double> drawingOffset = GetDrawingOffset();
+                double deltaX = drawingOffset.Item1;
+                double deltaY = drawingOffset.Item2;
+                int ingameX = (int)((e.GetPosition(this).X/_cellWidth - deltaX));
+                int ingameY = (int)((e.GetPosition(this).Y / _cellWidth) - deltaY);
 
-            LogCellInfo(ingameX, ingameY);
+                LogCellInfo(ingameX, ingameY);
+            }
         }
 
         private void LogCellInfo(int x, int y)


### PR DESCRIPTION
- NPCs are drawn in Dark Orange
- Players are drawn in Green
- A tooltip is displayed on mouseover (Thanks @Zonz ):
  - Players on the cell (Name, inBattle, Afk)
  - Npcs on the cell (Id, name, Type)
  - Links on the cell (Destination map)
-Type Description Property added to npcs (still needs most of the descriptions for the type ids)
-Code to calculate deltaX/Y for drawing moved to separate method to prevent code duplication