### PR TITLE
Moves and PP Current / Max in TeamView window

### DIFF
--- a/PROProtocol/PokemonMove.cs
+++ b/PROProtocol/PokemonMove.cs
@@ -1,4 +1,6 @@
-﻿namespace PROProtocol
+using System.Globalization;
+
+namespace PROProtocol
 {
     public class PokemonMove
     {
@@ -6,6 +8,8 @@
         public int Id { get; private set; }
         public int MaxPoints { get; private set; }
         public int CurrentPoints { get; set; }
+        
+        private TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
 
         public MovesManager.MoveData Data
         {
@@ -15,6 +19,14 @@
         public string Name
         {
             get { return Data?.Name; }
+        }
+        
+        public string Name_PP
+        {
+            get
+            {
+                return Name != null ? ti.ToTitleCase(Name) + ": " + CurrentPoints + " / " + MaxPoints : "";
+            }
         }
 
         public PokemonMove(int position, int id, int maxPoints, int currentPoints)

--- a/PROShine/Views/TeamView.xaml
+++ b/PROShine/Views/TeamView.xaml
@@ -23,6 +23,10 @@
                         <GridViewColumn Header="HP" DisplayMemberBinding="{Binding Health}"/>
                         <GridViewColumn Header="Remaining Exp" DisplayMemberBinding="{Binding Experience.RemainingExperience}"/>
                         <GridViewColumn Header="Item" DisplayMemberBinding="{Binding ItemHeld}"/>
+                        <GridViewColumn Header="Move 1" DisplayMemberBinding="{Binding Moves[0].Name_PP}"/>
+                        <GridViewColumn Header="Move 2" DisplayMemberBinding="{Binding Moves[1].Name_PP}"/>
+                        <GridViewColumn Header="Move 3" DisplayMemberBinding="{Binding Moves[2].Name_PP}"/>
+                        <GridViewColumn Header="Move 4" DisplayMemberBinding="{Binding Moves[3].Name_PP}"/>
                     </GridView>
                 </ListView.View>
             </ListView>


### PR DESCRIPTION
Same as Nymphetaminer's, but converts name to Title Case, and gets of rid of the error Visual Studio was giving me when a Pokemon has less than 4 moves. I also didn't think stretching the MainWindow was necessary.