### PR TITLE
Add Text Input Options

### DIFF
--- a/PROBot/BotClient.cs
+++ b/PROBot/BotClient.cs
@@ -31,6 +31,7 @@ namespace PROBot
         public event Action ClientChanged;
         public event Action ConnectionOpened;
         public event Action ConnectionClosed;
+        public event Action<TextOption> TextboxCreated;
 
         public PokemonEvolver PokemonEvolver { get; private set; }
         public MoveTeacher MoveTeacher { get; private set; }
@@ -38,6 +39,7 @@ namespace PROBot
         public AutoReconnector AutoReconnector { get; private set; }
         public MovementResynchronizer MovementResynchronizer { get; private set; }
         public OptionSlider[] Options { get; private set; }
+        public Dictionary<int, TextOption> TextOptions { get; set; }
         
         private bool _loginRequested;
 
@@ -58,6 +60,23 @@ namespace PROBot
                                            new OptionSlider("Option 4: ", "Custom option 4 for use in scripts", 4),
                                            new OptionSlider("Option 5: ", "Custom option 5 for use in scripts", 5)
             };
+            TextOptions = new Dictionary<int, TextOption>();
+        }
+
+        public void CreateText(int index, string content)
+        {
+            TextOptions[index] = new TextOption("Text " + index + ": ", "Custom text option " + index + " for use in scripts.", content);
+            TextboxCreated?.Invoke(TextOptions[index]);
+        }
+
+        public void CreateText(int index, string content, bool isName)
+        {
+            if (isName)
+                TextOptions[index] = new TextOption(content, "Custom text option " + index + " for use in scripts.", "");
+            else
+                TextOptions[index] = new TextOption("Text " + index + ": ", content, "");
+
+            TextboxCreated?.Invoke(TextOptions[index]);
         }
 
         public void LogMessage(string message)

--- a/PROBot/Modules/CustomOptions.cs
+++ b/PROBot/Modules/CustomOptions.cs
@@ -64,4 +64,56 @@ namespace PROBot.Modules
             _index = index;
         }
     }
+    
+    public class TextOption
+    {
+        public event Action StateChanged;
+
+        private string _name, _description, _content;
+
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    StateChanged?.Invoke();
+                }
+            }
+        }
+
+        public string Description
+        {
+            get { return _description; }
+            set
+            {
+                if (_description != value)
+                {
+                    _description = value;
+                    StateChanged?.Invoke();
+                }
+            }
+        }
+
+        public string Content {
+            get { return _content; }
+            set
+            {
+                if (_content != value)
+                {
+                    _content = value;
+                    StateChanged?.Invoke();
+                }
+            }
+        }
+
+        public TextOption(string name, string description, string content)
+        {
+            _name = name;
+            _description = description;
+            _content = content;
+        }
+    }
 }

--- a/PROBot/PROBot.csproj
+++ b/PROBot/PROBot.csproj
@@ -49,7 +49,7 @@
     <Compile Include="BotClient.cs" />
     <Compile Include="Modules\MovementResynchronizer.cs" />
     <Compile Include="Modules\MoveTeacher.cs" />
-    <Compile Include="Modules\OptionSlider.cs" />
+    <Compile Include="Modules\CustomOptions.cs" />
     <Compile Include="Modules\PokemonEvolver.cs" />
     <Compile Include="Pathfinding.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -307,6 +307,12 @@ namespace PROBot.Scripting
             _lua.Globals["setOptionName"] = new Action<int, string>(SetOptionName);
             _lua.Globals["setOptionDescription"] = new Action<int, string>(SetOptionDescription);
 
+            // Custom text option functions
+            _lua.Globals["setTextOption"] = new Action<int, string>(SetTextOption);
+            _lua.Globals["getTextOption"] = new Func<int, string>(GetTextOption);
+            _lua.Globals["setTextOptionName"] = new Action<int, string>(SetTextOptionName);
+            _lua.Globals["setTextOptionDescription"] = new Action<int, string>(SetTextOptionDescription);
+
             // File editing actions
             _lua.Globals["logToFile"] = new Action<string, DynValue, bool>(LogToFile);
             _lua.Globals["readLinesFromFile"] = new Func<string, string[]>(ReadLinesFromFile);

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -2596,5 +2596,50 @@ namespace PROBot.Scripting
 
             Bot.Options[option - 1].Description = content;
         }
+	
+        // API: Sets the text of the TextOption at a particular index, or creates it if it doesn't exist
+        private void SetTextOption(int index, string content)
+        {
+            if (!Bot.TextOptions.ContainsKey(index))
+            {
+                Bot.CreateText(index, content);
+                return;
+            }
+
+            Bot.TextOptions[index].Content = content;
+        }
+
+        // API: Returns the text content of the TextOption at a particular index, or an empty string if it doesn't exist
+        private string GetTextOption(int index)
+        {
+            if (!Bot.TextOptions.ContainsKey(index))
+                return "";
+            
+            return Bot.TextOptions[index].Content;
+        }
+
+        // API: Sets the name of the TextOption at a particular index, or creates it if it doesn't exist
+        private void SetTextOptionName(int index, string content)
+        {
+            if (!Bot.TextOptions.ContainsKey(index))
+            {
+                Bot.CreateText(index, content + ": ", true);
+                return;
+            }
+
+            Bot.TextOptions[index].Name = content + ": ";
+        }
+
+        // API: Sets the tooltip description of the TextOption at a particular index, or creates it if it doesn't exist
+        private void SetTextOptionDescription(int index, string content)
+        {
+            if (!Bot.TextOptions.ContainsKey(index))
+            {
+                Bot.CreateText(index, content, false);
+                return;
+            }
+
+            Bot.TextOptions[index].Description = content;
+        }
     }
 }

--- a/PROShine/Views/MainWindow.xaml
+++ b/PROShine/Views/MainWindow.xaml
@@ -199,6 +199,25 @@
                     </CheckBox.ToolTip>
                 </CheckBox>
             </WrapPanel>
+            <ItemsControl Name="TextOptions">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ToolTip="{Binding Description}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Content="{Binding Name}"/>
+                            <TextBox Grid.Column="1" Text="{Binding Content}" KeyDown="TextBox_KeyDown"/>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </WrapPanel>
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace PROShine
             Bot.ConnectionOpened += Bot_ConnectionOpened;
             Bot.ConnectionClosed += Bot_ConnectionClosed;
             Bot.MessageLogged += Bot_LogMessage;
+            Bot.TextboxCreated += Bot_TextboxCreated;
 
             foreach (var slider in Bot.Options)
             {

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -117,6 +117,16 @@ namespace PROShine
             TextOptions.ItemsSource = _textOptions = new ObservableCollection<TextOption>();
         }
 
+        private void TextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            // On pressing enter, take focus from the textbox and give it to the selected button in _views
+            // This is necessary to update the content of the TextOption
+            if (e.Key == Key.Enter || e.Key == Key.Return)
+                foreach (TabView view in _views)
+                    if (view.Button.IsChecked.Value)
+                        Keyboard.Focus(view.Button);
+        }
+
         public void Bot_TextOptionChanged()
         {
             Dispatcher.InvokeAsync(delegate

--- a/PROShine/Views/MainWindow.xaml.cs
+++ b/PROShine/Views/MainWindow.xaml.cs
@@ -14,6 +14,9 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+using PROBot.Modules;
 
 namespace PROShine
 {
@@ -45,6 +48,7 @@ namespace PROShine
         private int _queuePosition;
 
         private CheckBox[] _options = new CheckBox[5];
+        private ObservableCollection<TextOption> _textOptions;
 
         public MainWindow()
         {
@@ -109,6 +113,26 @@ namespace PROShine
 
             foreach (var option in _options)
                 option.Visibility = Visibility.Collapsed;
+                
+            TextOptions.ItemsSource = _textOptions = new ObservableCollection<TextOption>();
+        }
+
+        public void Bot_TextOptionChanged()
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                TextOptions.Items.Refresh();
+            });
+        }
+
+        public void Bot_TextboxCreated(TextOption option)
+        {
+            Dispatcher.InvokeAsync(delegate
+            {
+                _textOptions.Add(option);
+                option.StateChanged += Bot_TextOptionChanged;
+                TextOptions.Items.Refresh();
+            });
         }
 
         private void AddView(UserControl view, ContentControl content, ToggleButton button, bool visible = false)
@@ -268,6 +292,10 @@ namespace PROShine
                 {
                     lock (Bot)
                     {
+                        Bot.TextOptions.Clear();
+                        _textOptions.Clear();
+                        TextOptions.Items.Refresh();
+                        
                         foreach (var slider in Bot.Options)
                             slider.Reset();
 


### PR DESCRIPTION
Similar to the option sliders, but these have a text field for users to fill, for scripters to alter script behavior according to input.

This would go great with Melt's Pathfinder - you would be able to have it move you anywhere just by changing a text field, instead of editing a script and reloading it every time you want to change locations.

Credits to KingCookie from Discord for the idea.

As usual, usage:
```
tab = {"First", "Second", "Third", "Fourth", "Fifth"}

for i = 1, 5 do
	setTextOptionName(i, "Text Option " .. i)
	setTextOption(i, tab[i])
	setTextOptionDescription(i, "This is text option " .. i .. "'s description, set by a script.")
end


function onStart()
	
	if getTextOption(1) == "First" then
		log("You didn't change option 1.")
	else
		log("You changed option 1. Its new text is: \"" .. getTextOption(1) .. "\"")
	end
	
end
```