### PR TITLE
Fix get pokemon index on auto reconnected.

### DIFF
--- a/PROBot/BotClient.cs
+++ b/PROBot/BotClient.cs
@@ -137,7 +137,7 @@ namespace PROBot
             if (PokemonEvolver.Update()) return;
             if (MoveTeacher.Update()) return;
 
-            if (Game.IsMapLoaded && Game.AreNpcReceived && Game.IsInactive)
+            if (Game.IsMapLoaded && Game.AreNpcReceived && Game.IsInactive && Game.Team.Count > 0)
             {
                 ExecuteNextAction();
             }


### PR DESCRIPTION
Fix too fast execute script on reconnected when script use about pokemon functions.

Can detect on get all team members before execute script?