### PR TITLE
Map Info and Better NPC Data

### DIFF
--- a/PROBot/BotClient.cs
+++ b/PROBot/BotClient.cs
@@ -294,6 +294,7 @@ namespace PROBot
             if (canInteract)
             {
                 Game.TalkToNpc(target.Id);
+                target.CanBattle = false;
                 return true;
             }
             else

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -546,7 +546,7 @@ namespace PROBot.Scripting
                     var newLink = new Dictionary<string, DynValue>();
                     newLink["x"] = DynValue.NewNumber(coord.Item1);
                     newLink["y"] = DynValue.NewNumber(coord.Item2);
-                    newLink["name"] = DynValue.NewString(link.Key);
+                    newLink["name"] = DynValue.NewString(Bot.Game.Map.Links[coord.Item1, coord.Item2].DestinationMap);
                     links.Add(newLink);
                 }
             }

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -171,6 +171,8 @@ namespace PROBot.Scripting
             _lua.Globals["getDiscoverableItems"] = new Func<List<Dictionary<string, int>>>(GetDiscoverableItems);
             _lua.Globals["getNpcData"] = new Func<List<Dictionary<string, DynValue>>>(GetNpcData);
             _lua.Globals["getMapLinks"] = new Func<List<Dictionary<string, DynValue>>>(GetMapLinks);
+            _lua.Globals["getMapSize"] = new Func<Dictionary<string, int>>(GetMapSize);
+            _lua.Globals["getCellType"] = new Func<int, int, string>(GetCellType);
 
             _lua.Globals["hasItem"] = new Func<string, bool>(HasItem);
             _lua.Globals["getItemQuantity"] = new Func<string, int>(GetItemQuantity);
@@ -550,6 +552,30 @@ namespace PROBot.Scripting
             }
 
             return links;
+        }
+        
+        // API: Returns the dimensions of the current map.
+        private Dictionary<string, int> GetMapSize()
+        {
+            var mapSize = new Dictionary<string, int>();
+            mapSize["x"] = Bot.Game.Map.Width;
+            mapSize["y"] = Bot.Game.Map.Height;
+            return mapSize;
+        }
+
+        // API: Returns the cell type of the specified cell on the current map.
+        private string GetCellType(int x, int y)
+        {
+            Map map = Bot.Game.Map;
+
+            if (map.IsGrass(x, y)) return "Grass";
+            if (map.IsWater(x, y)) return "Water";
+            if (map.IsNormalGround(x, y)) return "Normal Ground";
+            if (map.IsIce(x, y)) return "Ice";
+            if (map.IsPC(x, y)) return "PC";
+            if (map.HasLink(x, y)) return "Link";
+
+            return "Collider";
         }
 
         // API: Returns true if the string contains the specified part, ignoring the case.

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -170,6 +170,7 @@ namespace PROBot.Scripting
             _lua.Globals["getActiveBerryTrees"] = new Func<List<Dictionary<string, int>>>(GetActiveBerryTrees);
             _lua.Globals["getDiscoverableItems"] = new Func<List<Dictionary<string, int>>>(GetDiscoverableItems);
             _lua.Globals["getNpcData"] = new Func<List<Dictionary<string, DynValue>>>(GetNpcData);
+            _lua.Globals["getMapLinks"] = new Func<List<Dictionary<string, DynValue>>>(GetMapLinks);
 
             _lua.Globals["hasItem"] = new Func<string, bool>(HasItem);
             _lua.Globals["getItemQuantity"] = new Func<string, int>(GetItemQuantity);
@@ -529,6 +530,23 @@ namespace PROBot.Scripting
                 lNpc.Add(npcData);
             }
             return lNpc;
+        }
+
+        // API: Returns an array of all map links on the current map - links limited to one per map for simplicity
+        public List<Dictionary<string, DynValue>> GetMapLinks()
+        {
+            var links = new List<Dictionary<string, DynValue>>();
+
+            foreach (var link in Bot.Game.Map.LinkDestinations)
+            {
+                var newLink = new Dictionary<string, DynValue>();
+                newLink["x"] = DynValue.NewNumber(link.Value[0].Item1);
+                newLink["y"] = DynValue.NewNumber(link.Value[0].Item2);
+                newLink["name"] = DynValue.NewString(link.Key);
+                links.Add(newLink);
+            }
+
+            return links;
         }
 
         // API: Returns true if the string contains the specified part, ignoring the case.

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -532,18 +532,21 @@ namespace PROBot.Scripting
             return lNpc;
         }
 
-        // API: Returns an array of all map links on the current map - links limited to one per map for simplicity
+        // API: Returns an array of all map links on the current map
         public List<Dictionary<string, DynValue>> GetMapLinks()
         {
             var links = new List<Dictionary<string, DynValue>>();
 
             foreach (var link in Bot.Game.Map.LinkDestinations)
             {
-                var newLink = new Dictionary<string, DynValue>();
-                newLink["x"] = DynValue.NewNumber(link.Value[0].Item1);
-                newLink["y"] = DynValue.NewNumber(link.Value[0].Item2);
-                newLink["name"] = DynValue.NewString(link.Key);
-                links.Add(newLink);
+                foreach (var coord in link.Value)
+                {
+                    var newLink = new Dictionary<string, DynValue>();
+                    newLink["x"] = DynValue.NewNumber(coord.Item1);
+                    newLink["y"] = DynValue.NewNumber(coord.Item2);
+                    newLink["name"] = DynValue.NewString(link.Key);
+                    links.Add(newLink);
+                }
             }
 
             return links;

--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -164,12 +164,12 @@ namespace PROBot.Scripting
             _lua.Globals["isPokemonUsable"] = new Func<int, bool>(IsPokemonUsable);
             _lua.Globals["getUsablePokemonCount"] = new Func<int>(GetUsablePokemonCount);
             _lua.Globals["hasMove"] = new Func<int, string, bool>(HasMove);
-            _lua.Globals["getActiveBattlers"] = new Func<Dictionary<string, Dictionary<string, int>>>(GetActiveBattlers);
+            _lua.Globals["getActiveBattlers"] = new Func<List<Dictionary<string, DynValue>>>(GetActiveBattlers);
             _lua.Globals["getActiveDigSpots"] = new Func<List<Dictionary<string, int>>>(GetActiveDigSpots);
             _lua.Globals["getActiveHeadbuttTrees"] = new Func<List<Dictionary<string, int>>>(GetActiveHeadbuttTrees);
             _lua.Globals["getActiveBerryTrees"] = new Func<List<Dictionary<string, int>>>(GetActiveBerryTrees);
             _lua.Globals["getDiscoverableItems"] = new Func<List<Dictionary<string, int>>>(GetDiscoverableItems);
-            _lua.Globals["getNpcData"] = new Func<List<Dictionary<string, string>>>(GetNpcData);
+            _lua.Globals["getNpcData"] = new Func<List<Dictionary<string, DynValue>>>(GetNpcData);
 
             _lua.Globals["hasItem"] = new Func<string, bool>(HasItem);
             _lua.Globals["getItemQuantity"] = new Func<string, int>(GetItemQuantity);
@@ -440,16 +440,17 @@ namespace PROBot.Scripting
             Bot.Logout(false);
         }
 
-        // API return an array of all NPCs that can be challenged on the current map. format : {"npcName" = {"x" = x, "y" = y}}
-        private Dictionary<string, Dictionary<string, int>> GetActiveBattlers()
+        // API: Returns an array of all NPCs that can be challenged on the current map. format : {index = {"x" = x, "y" = y}}
+        private List<Dictionary<string, DynValue>> GetActiveBattlers()
         {
-            var activeBattlers = new Dictionary<string, Dictionary<string, int>>();
+            var activeBattlers = new List<Dictionary<string, DynValue>>();
             foreach (Npc npc in Bot.Game.Map.Npcs.Where(npc => npc.CanBattle))
             {
-                var npcData = new Dictionary<string, int>();
-                npcData["x"] = npc.PositionX;
-                npcData["y"] = npc.PositionY;
-                activeBattlers[npc.Name] = npcData;
+                var npcData = new Dictionary<string, DynValue>();
+                npcData["x"] = DynValue.NewNumber(npc.PositionX);
+                npcData["y"] = DynValue.NewNumber(npc.PositionY);
+                npcData["name"] = DynValue.NewString(npc.Name);
+                activeBattlers.Add(npcData);
             }
             return activeBattlers;
         }
@@ -511,20 +512,20 @@ namespace PROBot.Scripting
             return items;
         }
 
-        // API return npc data on current map, format : { { "x" = x , "y" = y, "type" = type }, {...}, ... }
-        private List<Dictionary<string, string>> GetNpcData()
+        // API: Returns npc data on current map, format : { { "x" = x , "y" = y, "type" = type }, {...}, ... }
+        private List<Dictionary<string, DynValue>> GetNpcData()
         {
-            var lNpc = new List<Dictionary<string, string>>();
+            var lNpc = new List<Dictionary<string, DynValue>>();
             foreach (Npc npc in Bot.Game.Map.Npcs)
             {
-                var npcData = new Dictionary<string, string>();
-                npcData["x"] = npc.PositionX.ToString();
-                npcData["y"] = npc.PositionY.ToString();
-                npcData["type"] = npc.Type.ToString();
-                npcData["name"] = npc.Name;
-                npcData["isBattler"] = npc.IsBattler.ToString();
-                npcData["id"] = npc.Id.ToString();
-                npcData["los"] = npc.LosLength.ToString();
+                var npcData = new Dictionary<string, DynValue>();
+                npcData["x"] = DynValue.NewNumber(npc.PositionX);
+                npcData["y"] = DynValue.NewNumber(npc.PositionY);
+                npcData["type"] = DynValue.NewNumber(npc.Type);
+                npcData["name"] = DynValue.NewString(npc.Name);
+                npcData["isBattler"] = DynValue.NewBoolean(npc.IsBattler);
+                npcData["id"] = DynValue.NewNumber(npc.Id);
+                npcData["los"] = DynValue.NewNumber(npc.LosLength);
                 lNpc.Add(npcData);
             }
             return lNpc;

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -90,6 +90,9 @@ namespace PROShine.Views
 
         private void MapView_MouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (_bot.Running != BotClient.State.Started)
+                _bot.MoveToCell((int)_lastDisplayedCell.X, (int)_lastDisplayedCell.Y);
+                
             Keyboard.Focus(this);
         }
 

--- a/PROShine/Views/MapView.xaml.cs
+++ b/PROShine/Views/MapView.xaml.cs
@@ -90,8 +90,18 @@ namespace PROShine.Views
 
         private void MapView_MouseDown(object sender, MouseButtonEventArgs e)
         {
+            int x = (int)_lastDisplayedCell.X;
+            int y = (int)_lastDisplayedCell.Y;
+
+            Npc target = _bot.Game.Map.Npcs.FirstOrDefault(npc => npc.PositionX == x && npc.PositionY == y);
+
             if (_bot.Running != BotClient.State.Started)
-                _bot.MoveToCell((int)_lastDisplayedCell.X, (int)_lastDisplayedCell.Y);
+            {
+                if (target == null)
+                    _bot.MoveToCell(x, y);
+                else
+                    _bot.TalkToNpc(target);
+            }
                 
             Keyboard.Focus(this);
         }


### PR DESCRIPTION
Using DynValues enables you to directly make use of the data, instead of having to use tonumber in some cases.

getActiveBattlers converted from using names as keys to being indexed by numbers.

Fixed the issue with NPC's CanBattle still being true when battling them.